### PR TITLE
fix: add pointer to function that handles custom specifier b

### DIFF
--- a/get_function.c
+++ b/get_function.c
@@ -17,6 +17,7 @@ int (*find_format_handlers(const char *format))(va_list arg)
 		{"s", print_spec_s_match},
 		{"%", print_percent},
 		{"S", print_spec_S_match},
+		{"b", print_spec_b_match},
 		{NULL, NULL}
 	};
 


### PR DESCRIPTION
This adds the pointer to the function that handles custom specifier b to find_func array inside the get_function.c file.